### PR TITLE
Modernize schema embed code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ sdk/java/build
 sdk/java/gradle
 sdk/java/gradlew
 sdk/java/gradlew.bat
+
+schema-embed.json

--- a/provider/cmd/pulumi-resource-kafka/embed.go
+++ b/provider/cmd/pulumi-resource-kafka/embed.go
@@ -1,0 +1,22 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	_ "embed" // to embed schema
+)
+
+//go:embed schema-embed.json
+var pulumiSchema []byte


### PR DESCRIPTION
This simplifies linting the code as it now compiles without the results of go:generate needing to be checked in.