### PR TITLE
Replace docker images

### DIFF
--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -1,16 +1,18 @@
 version: '2'
 services:
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: docker.io/bitnami/zookeeper:3.9
     expose:
       - "2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.4
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CFG_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+    depends_on:
+      - zookeeper


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-kafka/issues/408

The previous ones were unsupported for a while and were deleted from docker hub causing ci failures.