### PR TITLE
Embed version in SDKs

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -8,3 +8,14 @@ plugins:
   - name: terraform
     version: "1.0.16"
     kind: converter
+
+worktreeAllowedChanges: |-
+  sdk/**/pulumi-plugin.json
+  sdk/dotnet/Pulumi.*.csproj
+  sdk/go/*/internal/pulumiUtilities.go
+  sdk/nodejs/package.json
+  sdk/python/pyproject.toml
+
+publish:
+  goSdk:
+    usePush: true

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -9,6 +9,7 @@ plugins:
     version: "1.0.16"
     kind: converter
 
+# These files are updated with the real version number
 worktreeAllowedChanges: |-
   sdk/**/pulumi-plugin.json
   sdk/dotnet/Pulumi.*.csproj

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
       continue-on-error: true
       run: make upstream
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.58.0
         working-directory: provider

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,6 +102,13 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
+          sdk/go/*/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -103,6 +103,13 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
+          sdk/go/*/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,13 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
+          sdk/go/*/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts
@@ -359,9 +366,14 @@ jobs:
         repo: pulumi/pulumictl
     - id: version
       uses: pulumi/provider-version-action@v1
-    - name: Add SDK version tag
-      run: git tag "sdk/v${{ steps.version.outputs.version }}" && git push origin
-        "sdk/v${{ steps.version.outputs.version }}"
+    - uses: pulumi/publish-go-sdk-action@v1
+      with:
+        repository: ${{ github.repository }}
+        base-ref: ${{ github.sha }}
+        source: sdk
+        path: sdk
+        version: ${{ steps.version.outputs.version }}
+        additive: false
 
   clean_up_release_labels:
     name: Clean up release labels

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -112,6 +112,13 @@ jobs:
       run: make build_${{ matrix.language }}
     - name: Check worktree clean
       uses: pulumi/git-status-check-action@v1
+      with:
+        allowed-changes: |
+          sdk/**/pulumi-plugin.json
+          sdk/dotnet/Pulumi.*.csproj
+          sdk/go/*/internal/pulumiUtilities.go
+          sdk/nodejs/package.json
+          sdk/python/pyproject.toml
     - name: Compress SDK folder
       run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
     - name: Upload artifacts

--- a/provider/cmd/pulumi-resource-kafka/schema.json
+++ b/provider/cmd/pulumi-resource-kafka/schema.json
@@ -14,6 +14,9 @@
     },
     "language": {
         "csharp": {
+            "packageReferences": {
+                "Pulumi": "3.*"
+            },
             "namespaces": {
                 "kafka": "Kafka"
             },
@@ -34,6 +37,9 @@
             "respectSchemaVersion": true
         },
         "python": {
+            "requires": {
+                "pulumi": "\u003e=3.0.0,\u003c4.0.0"
+            },
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/Mongey/terraform-provider-kafka)\n\u003e distributed under [MIT](https://mit-license.org/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-kafka` repo](https://github.com/pulumi/pulumi-kafka/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-kafka` repo](https://github.com/Mongey/terraform-provider-kafka/issues).",
             "compatibility": "tfbridge20",
             "respectSchemaVersion": true,

--- a/provider/cmd/pulumi-resource-kafka/schema.json
+++ b/provider/cmd/pulumi-resource-kafka/schema.json
@@ -14,38 +14,29 @@
     },
     "language": {
         "csharp": {
-            "packageReferences": {
-                "Pulumi": "3.*"
-            },
             "namespaces": {
                 "kafka": "Kafka"
             },
-            "compatibility": "tfbridge20"
+            "compatibility": "tfbridge20",
+            "respectSchemaVersion": true
         },
         "go": {
             "importBasePath": "github.com/pulumi/pulumi-kafka/sdk/v3/go/kafka",
             "generateResourceContainerTypes": true,
-            "generateExtraInputTypes": true
+            "generateExtraInputTypes": true,
+            "respectSchemaVersion": true
         },
         "nodejs": {
             "packageDescription": "A Pulumi package for creating and managing Kafka.",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/Mongey/terraform-provider-kafka)\n\u003e distributed under [MIT](https://mit-license.org/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-kafka` repo](https://github.com/pulumi/pulumi-kafka/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-kafka` repo](https://github.com/Mongey/terraform-provider-kafka/issues).",
-            "dependencies": {
-                "@pulumi/pulumi": "^3.0.0"
-            },
-            "devDependencies": {
-                "@types/mime": "^2.0.0",
-                "@types/node": "^10.0.0"
-            },
             "compatibility": "tfbridge20",
-            "disableUnionOutputTypes": true
+            "disableUnionOutputTypes": true,
+            "respectSchemaVersion": true
         },
         "python": {
-            "requires": {
-                "pulumi": "\u003e=3.0.0,\u003c4.0.0"
-            },
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/Mongey/terraform-provider-kafka)\n\u003e distributed under [MIT](https://mit-license.org/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi-kafka` repo](https://github.com/pulumi/pulumi-kafka/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-provider-kafka` repo](https://github.com/Mongey/terraform-provider-kafka/issues).",
             "compatibility": "tfbridge20",
+            "respectSchemaVersion": true,
             "pyproject": {
                 "enabled": true
             }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -108,6 +108,9 @@ func Provider() tfbridge.ProviderInfo {
 		Python: (func() *tfbridge.PythonInfo {
 			i := &tfbridge.PythonInfo{
 				RespectSchemaVersion: true,
+				Requires: map[string]string{
+					"pulumi": ">=3.0.0,<4.0.0",
+				},
 			}
 			i.PyProject.Enabled = true
 			return i
@@ -125,6 +128,9 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		CSharp: &tfbridge.CSharpInfo{
 			RespectSchemaVersion: true,
+			PackageReferences: map[string]string{
+				"Pulumi": "3.*",
+			},
 			Namespaces: map[string]string{
 				mainPkg: "Kafka",
 			},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -103,19 +103,12 @@ func Provider() tfbridge.ProviderInfo {
 			"kafka_topic": {Docs: noDocs},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
-			Dependencies: map[string]string{
-				"@pulumi/pulumi": "^3.0.0",
-			},
-			DevDependencies: map[string]string{
-				"@types/node": "^10.0.0", // so we can access strongly typed node definitions.
-				"@types/mime": "^2.0.0",
-			},
+			RespectSchemaVersion: true,
 		},
 		Python: (func() *tfbridge.PythonInfo {
 			i := &tfbridge.PythonInfo{
-				Requires: map[string]string{
-					"pulumi": ">=3.0.0,<4.0.0",
-				}}
+				RespectSchemaVersion: true,
+			}
 			i.PyProject.Enabled = true
 			return i
 		})(),
@@ -128,11 +121,10 @@ func Provider() tfbridge.ProviderInfo {
 				mainPkg,
 			),
 			GenerateResourceContainerTypes: true,
+			RespectSchemaVersion:           true,
 		},
 		CSharp: &tfbridge.CSharpInfo{
-			PackageReferences: map[string]string{
-				"Pulumi": "3.*",
-			},
+			RespectSchemaVersion: true,
 			Namespaces: map[string]string{
 				mainPkg: "Kafka",
 			},

--- a/sdk/dotnet/Pulumi.Kafka.csproj
+++ b/sdk/dotnet/Pulumi.Kafka.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
+    <PackageReference Include="Pulumi" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/dotnet/Pulumi.Kafka.csproj
+++ b/sdk/dotnet/Pulumi.Kafka.csproj
@@ -9,6 +9,7 @@
     <PackageProjectUrl>https://pulumi.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-kafka</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
+    <Version>3.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -44,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="[3.54.1.0,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "kafka"
+  "name": "kafka",
+  "version": "3.0.0-alpha.0+dev"
 }

--- a/sdk/go/kafka/internal/pulumiUtilities.go
+++ b/sdk/go/kafka/internal/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("3.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 
-	version := SdkVersion
+	version := semver.MustParse("3.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/go/kafka/pulumi-plugin.json
+++ b/sdk/go/kafka/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "kafka"
+  "name": "kafka",
+  "version": "3.0.0-alpha.0+dev"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/kafka",
-    "version": "${VERSION}",
+    "version": "3.0.0-alpha.0+dev",
     "description": "A Pulumi package for creating and managing Kafka.",
     "keywords": [
         "pulumi",
@@ -13,15 +13,15 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0"
+        "@pulumi/pulumi": "^3.42.0"
     },
     "devDependencies": {
-        "@types/mime": "^2.0.0",
-        "@types/node": "^10.0.0",
+        "@types/node": "^14",
         "typescript": "^4.3.5"
     },
     "pulumi": {
         "resource": true,
-        "name": "kafka"
+        "name": "kafka",
+        "version": "3.0.0-alpha.0+dev"
     }
 }

--- a/sdk/python/pulumi_kafka/pulumi-plugin.json
+++ b/sdk/python/pulumi_kafka/pulumi-plugin.json
@@ -1,4 +1,5 @@
 {
   "resource": true,
-  "name": "kafka"
+  "name": "kafka",
+  "version": "3.0.0-alpha.0+dev"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
   name = "pulumi_kafka"
   description = "A Pulumi package for creating and managing Kafka."
-  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
   keywords = ["pulumi", "kafka"]
   readme = "README.md"
   requires-python = ">=3.8"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
   name = "pulumi_kafka"
   description = "A Pulumi package for creating and managing Kafka."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi", "semver>=2.8.1"]
   keywords = ["pulumi", "kafka"]
   readme = "README.md"
   requires-python = ">=3.8"
-  version = "0.0.0"
+  version = "3.0.0a0+dev"
   [project.license]
     text = "Apache-2.0"
   [project.urls]


### PR DESCRIPTION
Part of https://github.com/pulumi/ci-mgmt/issues/915

1. Enable embedding version number in each language.
2. Configure CI to allow changes to files which include the version number and use new push-based Go SDK publishing.
3. Remove explicit dependencies (defer to the languages's defaults).