### PR TITLE
Remove custom worktreeAllowedChanges

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -8,7 +8,3 @@ plugins:
   - name: terraform
     version: "1.0.16"
     kind: converter
-
-publish:
-  goSdk:
-    usePush: true

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -9,14 +9,6 @@ plugins:
     version: "1.0.16"
     kind: converter
 
-# These files are updated with the real version number
-worktreeAllowedChanges: |-
-  sdk/**/pulumi-plugin.json
-  sdk/dotnet/Pulumi.*.csproj
-  sdk/go/*/internal/pulumiUtilities.go
-  sdk/nodejs/package.json
-  sdk/python/pyproject.toml
-
 publish:
   goSdk:
     usePush: true


### PR DESCRIPTION
1. The default option will now work fine here and this option is being removed in https://github.com/pulumi/ci-mgmt/pull/1005
2. Remove `publish.goSdk` config. This had no effect as `publish.goSdk.usePush` defaults to true

Workflows will be re-generated on next nightly CI upgrade.