### PR TITLE
Add force delete option for Kafka resources and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# CHANGELOG
+
+## HEAD (Unreleased)
+
+* Add `force_delete_resources` option to allow deleting Kafka resources when the Kafka cluster is unresponsive
+  * This can be set via the `KAFKA_FORCE_DELETE_RESOURCES` environment variable or in the provider configuration
+  * When enabled, resources will be removed from state even if the Kafka cluster cannot be reached
+
+## 3.0.0 (2023-01-17)
+
+* Upgrade to v3.0.0 of the pulumi-terraform-bridge
+
+## 2.0.0 (2022-06-29)
+
+* Upgrade to v2.0.0 of the pulumi-terraform-bridge
+
+## 1.5.0 (2022-05-25)
+
+* Upgrade to v0.9.0 of the Kafka Terraform Provider
+
+## 1.4.0 (2022-03-30)
+
+* Upgrade to v4.5.0 of the pulumi-terraform-bridge
+
+## 1.3.0 (2021-11-11)
+
+* Upgrade to v4.3.0 of the pulumi-terraform-bridge
+
+## 1.2.0 (2021-11-04)
+
+* Upgrade to terraform-bridge 3.11.0
+* Upgrade to pulumi 3.17.0
+
+## 1.1.0 (2021-10-19)
+
+* Upgrade to v0.5.0 of the Kafka Terraform Provider
+
+## 1.0.0 (2021-04-19)
+
+* Depend on Pulumi 3.0, which includes improvements to Python resource arguments and key translation, Go SDK performance,
+  Node SDK performance, general availability of Automation API, and more.
+
+## 0.4.0 (2021-04-12)
+
+* Upgrade to pulumi-terraform-bridge v2.23.0
+
+## 0.3.1 (2021-03-23)
+
+* Upgrade to pulumi-terraform-bridge v2.22.1  
+  **Please Note:** This includes a bug fix to the refresh operation regarding arrays
+
+## 0.3.0 (2021-03-15)
+
+* Upgrade to pulumi-terraform-bridge v2.21.0
+* Release macOS arm64 binary
+
+## 0.2.0 (2021-02-19)
+
+* Upgrade to v0.3.0 of the Kafka Terraform Provider
+
+## 0.1.0 (2021-01-19)
+
+* Initial creation of the provider against v0.2.11 of the Kafka Terraform Provider 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -37,3 +37,4 @@ The Kafka provider is available as a package in all Pulumi languages:
 - `skipTlsVerify` (Boolean) Set this to true only if the target Kafka server is an insecure development instance.
 - `timeout` (Number) Timeout in seconds
 - `tlsEnabled` (Boolean) Enable communication with the Kafka Cluster over TLS.
+- `force_delete_resources` (Boolean) Force delete Kafka resources even if the Kafka cluster is not responsive. This is useful when you've deleted the Kafka cluster but resources still exist in the Pulumi/Terraform state. Default is false.

--- a/examples/force-delete-py/Pulumi.yaml
+++ b/examples/force-delete-py/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: kafka-force-delete-py
+runtime: python
+description: A Kafka example demonstrating force deletion of resources in Python 

--- a/examples/force-delete-py/README.md
+++ b/examples/force-delete-py/README.md
@@ -1,0 +1,42 @@
+# Kafka Force Delete Example (Python)
+
+This example demonstrates how to use the `force_delete_resources` option to allow deleting Kafka resources when the Kafka cluster is unresponsive, using Python.
+
+## Running the Example
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Set up your Kafka cluster credentials:
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=your-kafka-bootstrap-servers
+```
+
+3. Run `pulumi up` to create the resources:
+
+```bash
+pulumi up
+```
+
+4. To demonstrate force deletion, you can simulate a Kafka cluster being unavailable by:
+   - Shutting down your Kafka cluster
+   - Or changing the bootstrap servers to an invalid value:
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=invalid-server:9092
+export KAFKA_FORCE_DELETE_RESOURCES=true
+```
+
+5. Run `pulumi destroy` to delete the resources:
+
+```bash
+pulumi destroy
+```
+
+With `KAFKA_FORCE_DELETE_RESOURCES=true`, the resources will be removed from the Pulumi state even though the Kafka cluster is unreachable. 

--- a/examples/force-delete-py/__main__.py
+++ b/examples/force-delete-py/__main__.py
@@ -1,0 +1,39 @@
+import pulumi
+import pulumi_kafka as kafka
+
+# Create a Kafka provider instance with force_delete_resources enabled
+kafka_provider = kafka.Provider("kafka-provider",
+    bootstrap_servers=["localhost:9092"],  # Replace with your Kafka bootstrap servers
+    # Enable force deletion of resources when Kafka is unresponsive
+    # This can also be set via the KAFKA_FORCE_DELETE_RESOURCES environment variable
+    force_delete_resources=True
+)
+
+# Create a Kafka topic using our provider with force_delete_resources enabled
+topic = kafka.Topic("example-topic",
+    name="example-topic",
+    partitions=1,
+    replication_factor=1,
+    config={
+        "cleanup.policy": "delete",
+        "retention.ms": "86400000",  # 1 day
+    },
+    opts=pulumi.ResourceOptions(provider=kafka_provider)
+)
+
+# Export the topic name
+pulumi.export("topic_name", topic.name)
+
+# Create an ACL using our provider with force_delete_resources enabled
+acl = kafka.Acl("example-acl",
+    acl_resource_name=topic.name,
+    acl_resource_type="Topic",
+    acl_principal="User:example",
+    acl_host="*",
+    acl_operation="Read",
+    acl_permission_type="Allow",
+    opts=pulumi.ResourceOptions(provider=kafka_provider)
+)
+
+# Export the ACL ID
+pulumi.export("acl_id", acl.id) 

--- a/examples/force-delete-py/requirements.txt
+++ b/examples/force-delete-py/requirements.txt
@@ -1,0 +1,2 @@
+pulumi>=3.0.0,<4.0.0
+pulumi-kafka>=3.0.0 

--- a/examples/force-delete/Pulumi.yaml
+++ b/examples/force-delete/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: kafka-force-delete
+runtime: nodejs
+description: A Kafka example demonstrating force deletion of resources 

--- a/examples/force-delete/README.md
+++ b/examples/force-delete/README.md
@@ -1,0 +1,34 @@
+# Kafka Force Delete Example
+
+This example demonstrates how to use the `force_delete_resources` option to allow deleting Kafka resources when the Kafka cluster is unresponsive.
+
+## Running the Example
+
+1. Start by setting up your Kafka cluster credentials:
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=your-kafka-bootstrap-servers
+```
+
+2. Run `pulumi up` to create the resources:
+
+```bash
+pulumi up
+```
+
+3. To demonstrate force deletion, you can simulate a Kafka cluster being unavailable by:
+   - Shutting down your Kafka cluster
+   - Or changing the bootstrap servers to an invalid value:
+
+```bash
+export KAFKA_BOOTSTRAP_SERVERS=invalid-server:9092
+export KAFKA_FORCE_DELETE_RESOURCES=true
+```
+
+4. Run `pulumi destroy` to delete the resources:
+
+```bash
+pulumi destroy
+```
+
+With `KAFKA_FORCE_DELETE_RESOURCES=true`, the resources will be removed from the Pulumi state even though the Kafka cluster is unreachable. 

--- a/examples/force-delete/index.ts
+++ b/examples/force-delete/index.ts
@@ -1,0 +1,37 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as kafka from "@pulumi/kafka";
+
+// Create a Kafka provider instance with force_delete_resources enabled
+const kafkaProvider = new kafka.Provider("kafka-provider", {
+    bootstrapServers: ["localhost:9092"], // Replace with your Kafka bootstrap servers
+    // Enable force deletion of resources when Kafka is unresponsive
+    // This can also be set via the KAFKA_FORCE_DELETE_RESOURCES environment variable
+    forceDeleteResources: true,
+});
+
+// Create a Kafka topic using our provider with force_delete_resources enabled
+const topic = new kafka.Topic("example-topic", {
+    name: "example-topic",
+    partitions: 1,
+    replicationFactor: 1,
+    config: {
+        "cleanup.policy": "delete",
+        "retention.ms": "86400000", // 1 day
+    },
+}, { provider: kafkaProvider });
+
+// Export the topic name
+export const topicName = topic.name;
+
+// Create an ACL using our provider with force_delete_resources enabled
+const acl = new kafka.Acl("example-acl", {
+    aclResourceName: topic.name,
+    aclResourceType: "Topic",
+    aclPrincipal: "User:example",
+    aclHost: "*",
+    aclOperation: "Read",
+    aclPermissionType: "Allow",
+}, { provider: kafkaProvider });
+
+// Export the ACL ID
+export const aclId = acl.id; 

--- a/examples/force-delete/package.json
+++ b/examples/force-delete/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "kafka-force-delete",
+    "version": "0.1.0",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/kafka": "^3.0.0"
+    }
+} 

--- a/examples/force-delete/tsconfig.json
+++ b/examples/force-delete/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+} 

--- a/provider/kafka/force_delete_provider.go
+++ b/provider/kafka/force_delete_provider.go
@@ -1,0 +1,125 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	original "github.com/Mongey/terraform-provider-kafka/kafka"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ForceDeleteProviderFactoryWrapper wraps the original provider factory and adds force_delete_resources option
+func ForceDeleteProviderFactoryWrapper() *schema.Provider {
+	originalProvider := original.Provider()
+	
+	// Add the force_delete_resources config option
+	originalProvider.Schema["force_delete_resources"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		DefaultFunc: schema.EnvDefaultFunc("KAFKA_FORCE_DELETE_RESOURCES", false),
+		Description: "Force delete Kafka resources even if the Kafka cluster is not responsive",
+	}
+
+	// Save the original create/read/update/delete functions
+	resources := map[string]*schema.Resource{}
+	for resourceName, resource := range originalProvider.ResourcesMap {
+		origDeleteContext := resource.DeleteContext
+		
+		// Wrap the delete operation with our force delete capability
+		resources[resourceName] = &schema.Resource{
+			Schema:       resource.Schema,
+			CreateContext: resource.CreateContext,
+			ReadContext:   resource.ReadContext,
+			UpdateContext: resource.UpdateContext,
+			DeleteContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+				// Get the force_delete_resources configuration
+				forceDelete := false
+				if config, ok := m.(*schema.ResourceData); ok {
+					forceDelete = config.Get("force_delete_resources").(bool)
+				}
+
+				// Call the original delete function
+				diags := origDeleteContext(ctx, d, m)
+				
+				// If there's an error and force_delete_resources is true, handle it
+				if diags.HasError() && forceDelete {
+					// Check if the error is related to Kafka connectivity
+					errorMsg := diagsToString(diags)
+					if isKafkaConnectivityError(errorMsg) {
+						// Log the forced deletion
+						fmt.Printf("[WARN] Force deleting resource %s due to Kafka connectivity issues. Error: %s\n", 
+							d.Id(), errorMsg)
+						
+						// Clear the diagnostics and mark the resource as deleted
+						d.SetId("")
+						return nil
+					}
+				}
+				
+				return diags
+			},
+			Importer:     resource.Importer,
+			Timeouts:     resource.Timeouts,
+			CustomizeDiff: resource.CustomizeDiff,
+			Description:  resource.Description,
+			DeprecationMessage: resource.DeprecationMessage,
+		}
+	}
+
+	// Replace the resources with our wrapped versions
+	originalProvider.ResourcesMap = resources
+	
+	return originalProvider
+}
+
+// isKafkaConnectivityError checks if the error is related to Kafka connectivity
+func isKafkaConnectivityError(errorMsg string) bool {
+	errorPatterns := []string{
+		"connection refused",
+		"no such host",
+		"i/o timeout",
+		"cannot connect to kafka",
+		"broker not available",
+		"kafka server: Request timed out",
+		"kafka cluster is not responsive",
+		"failed to connect to kafka",
+	}
+
+	errorMsg = strings.ToLower(errorMsg)
+	for _, pattern := range errorPatterns {
+		if strings.Contains(errorMsg, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// diagsToString converts diagnostics to a string
+func diagsToString(diags diag.Diagnostics) string {
+	var builder strings.Builder
+	for _, diag := range diags {
+		if diag.Severity == diag.Error {
+			builder.WriteString(diag.Summary)
+			builder.WriteString(": ")
+			builder.WriteString(diag.Detail)
+			builder.WriteString("\n")
+		}
+	}
+	return builder.String()
+} 

--- a/provider/kafka/force_delete_provider_test.go
+++ b/provider/kafka/force_delete_provider_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsKafkaConnectivityError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		errorMsg string
+		expected bool
+	}{
+		{
+			name:     "connection refused error",
+			errorMsg: "Error: connection refused",
+			expected: true,
+		},
+		{
+			name:     "no such host error",
+			errorMsg: "Error: no such host",
+			expected: true,
+		},
+		{
+			name:     "i/o timeout error",
+			errorMsg: "Error: i/o timeout",
+			expected: true,
+		},
+		{
+			name:     "cannot connect to kafka error",
+			errorMsg: "Error: cannot connect to kafka",
+			expected: true,
+		},
+		{
+			name:     "broker not available error",
+			errorMsg: "Error: broker not available",
+			expected: true,
+		},
+		{
+			name:     "kafka server timeout error",
+			errorMsg: "Error: kafka server: Request timed out",
+			expected: true,
+		},
+		{
+			name:     "kafka cluster not responsive error",
+			errorMsg: "Error: kafka cluster is not responsive",
+			expected: true,
+		},
+		{
+			name:     "failed to connect to kafka error",
+			errorMsg: "Error: failed to connect to kafka",
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			errorMsg: "Error: invalid configuration",
+			expected: false,
+		},
+		{
+			name:     "empty error",
+			errorMsg: "",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isKafkaConnectivityError(tc.errorMsg)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestDiagsToString(t *testing.T) {
+	diags := diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Error Summary",
+			Detail:   "Error Detail",
+		},
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Warning Summary",
+			Detail:   "Warning Detail",
+		},
+	}
+
+	result := diagsToString(diags)
+	assert.Contains(t, result, "Error Summary")
+	assert.Contains(t, result, "Error Detail")
+	assert.NotContains(t, result, "Warning Summary")
+	assert.NotContains(t, result, "Warning Detail")
+} 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -30,6 +30,7 @@ import (
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 
 	"github.com/pulumi/pulumi-kafka/provider/v3/pkg/version"
+	customkafka "github.com/pulumi/pulumi-kafka/provider/v3/kafka"
 )
 
 // all of the token components used below.
@@ -48,7 +49,7 @@ var metadata []byte
 
 // Provider returns additional overlaid schema and metadata associated with the provider.
 func Provider() tfbridge.ProviderInfo {
-	p := shimv2.NewProvider(kafka.Provider())
+	p := shimv2.NewProvider(customkafka.ForceDeleteProviderFactoryWrapper())
 	prov := tfbridge.ProviderInfo{
 		P:                 p,
 		Name:              "kafka",
@@ -84,6 +85,14 @@ func Provider() tfbridge.ProviderInfo {
 						"KAFKA_ENABLE_TLS",
 					},
 					Value: true,
+				},
+			},
+			"force_delete_resources": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{
+						"KAFKA_FORCE_DELETE_RESOURCES",
+					},
+					Value: false,
 				},
 			},
 		},


### PR DESCRIPTION
This pull request introduces a new feature to the Kafka provider, allowing for the forced deletion of Kafka resources when the Kafka cluster is unresponsive. The changes include updates to documentation, examples, and the provider code to support this feature.

### New Feature: Force Delete Kafka Resources

* **Documentation Updates:**
  - Added `force_delete_resources` option to `CHANGELOG.md` and `docs/_index.md` to document the new feature. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R63) [[2]](diffhunk://#diff-c842590019e88255dcb723f9dfdadc9185e22a2f4fc7010f1ec3c404759e5540R40)

* **Examples:**
  - Added Python and Node.js examples demonstrating the use of the `force_delete_resources` option. This includes `Pulumi.yaml`, `README.md`, and code files for each example. [[1]](diffhunk://#diff-9a9e3618a90076088a6650461be40f8215422418ecec667690e9890af58be9fcR1-R3) [[2]](diffhunk://#diff-d198dde5c5caafc3b7b5523dfedaa43a44193074510cd19892c141b10c33abc1R1-R42) [[3]](diffhunk://#diff-aee1868b636d33dffd3f724e7e11afa2c1adf7c6fb18e9f2a38d10056c903661R1-R39) [[4]](diffhunk://#diff-e94524edca01deaa06ff0a965358a6e8c225dc9e0210c9684366ccdd1919c5b6R1-R2) [[5]](diffhunk://#diff-1f80cc331b4d2cda46a1f19af8bb6427de6e0fc7afc52b321d98c177619a9e99R1-R3) [[6]](diffhunk://#diff-e3e2005fffbe98fea9786db935e903b3f724f3cb2994d378a151bc21057519dfR1-R34) [[7]](diffhunk://#diff-46e6cd1739f3b73e315f0b628b94a49494d31f6838c0a87c14766c0018812b37R1-R37) [[8]](diffhunk://#diff-0334059a7db030b2d26523a87b590748a8d85fc22c37a0a6c2c53a5efb5c7c62R1-R11) [[9]](diffhunk://#diff-ebbc3b77f73c11fa36409fa55efcc243a2d30cbd39f26262a399f77ebc81a54bR1-R19)

* **Provider Code:**
  - Implemented the `force_delete_resources` option in the Kafka provider, including a wrapper for the original provider factory and logic to handle forced deletions. [[1]](diffhunk://#diff-eb81f68a4eed08ca718e369a40956f2a7fd2a221f95fb4482cf5696c26ede980R1-R125) [[2]](diffhunk://#diff-34c57e622183cb0d8dd0d3f9eaa0861b3340120e9b2ad811bac7ac7be4cea4b1R33) [[3]](diffhunk://#diff-34c57e622183cb0d8dd0d3f9eaa0861b3340120e9b2ad811bac7ac7be4cea4b1L51-R52) [[4]](diffhunk://#diff-34c57e622183cb0d8dd0d3f9eaa0861b3340120e9b2ad811bac7ac7be4cea4b1R90-R97)

* **Tests:**
  - Added tests for the new `force_delete_resources` functionality, ensuring proper handling of Kafka connectivity errors and conversion of diagnostics to strings.